### PR TITLE
Check 'TestingBotWebDriver' module is loaded before attempting to access properties on it.

### DIFF
--- a/extensions/testingbot/TestingBotExtension.php
+++ b/extensions/testingbot/TestingBotExtension.php
@@ -26,6 +26,11 @@ class TestingBotExtension extends \Codeception\Platform\Extension {
 		$api = new TestingBotAPI($key, $secret);
 
 		$current = $e->getTest()->getMetadata()->getCurrent();
+
+		if (!array_key_exists("\TestingBotWebDriver", $current["modules"])) {
+			return;
+		}
+
 		$sessionID = $current["modules"]["\TestingBotWebDriver"]->webDriver->getSessionID();
 
 		$api->updateJob($sessionID, array('success' => false, 'status_message' => $e->getFail()->getMessage(), 'name' => $e->getTest()->toString()));
@@ -38,6 +43,11 @@ class TestingBotExtension extends \Codeception\Platform\Extension {
 		$api = new TestingBotAPI($key, $secret);
 
 		$current = $e->getTest()->getMetadata()->getCurrent();
+
+		if (!array_key_exists("\TestingBotWebDriver", $current["modules"])) {
+			return;
+		}
+
 		$sessionID = $current["modules"]["\TestingBotWebDriver"]->webDriver->getSessionID();
 
 		$api->updateJob($sessionID, array('success' => true, 'name' => $e->getTest()->toString()));


### PR DESCRIPTION
If 'TestingBotExtension' is loaded and a test environment is run which does not use the 'TestingBotWebDriver' module, Codeception will crash at the end of the first test with

```
  [PHPUnit_Framework_Exception]
  Undefined index: \TestingBotWebDriver
```

This PR patches this by checking to see if 'TestingBotWebDriver' is in the current modules list before trying to access any properties on it.

This is not an ideal fix, as a 'TestingBotAPI' object is still instantiated before the current modules list is checked and the extension quits.
